### PR TITLE
Add: all contributors to zenodo file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -19,6 +19,70 @@
         "affiliation": "",
         "name": "Batisse, Alexandre",
         "orcid": "0000-0001-7912-3422"
+      },
+      {
+        "affiliation": "",
+        "name": "Holdgraf, Chris"
+      },
+      {
+        "affiliation": "",
+        "name": "Solvik, Kylen"
+      },
+      {
+        "affiliation": "",
+        "name": "Ogasawara, Ivan"
+      },
+      {
+        "affiliation": "",
+        "name": "Brett, Matthew"
+      },
+      {
+        "affiliation": "",
+        "name": "Sundell, Erik"
+      },
+      {
+        "affiliation": "",
+        "name": "Chen, Zehua"
+      },
+      {
+        "affiliation": "",
+        "name": "Ogasawara, Ivan"
+      },
+      {
+        "affiliation": "",
+        "name": "Joseph, Max"
+      },
+      {
+        "affiliation": "",
+        "name": "Lau, Sam"
+      },
+      {
+        "affiliation": "",
+        "name": "Roken, Ariel"
+      },
+      {
+        "affiliation": "",
+        "name": "Willing, Carol"
+      },
+      {
+        "affiliation": "",
+        "name": "Mason, James"
+      },
+      {
+        "affiliation": "",
+        "name": "Bantilan, Niels"
+      },
+      {
+        "affiliation": "",
+        "name": "Moss, Steve"
+      },
+      {
+        "affiliation": "",
+        "name": "Bantilan, Niels"
+      },
+      {
+        "affiliation": "",
+        "name": "Kashyap, Sumit"
       }
     ],
     "keywords": [


### PR DESCRIPTION
This adds all of the previous contributors that were removed when i moved to the .zenodo.json file.

We should create a new release once the open PR is merged next week to recognize everyone. ideally we can also add all of these folks to our contributor section in the readme too. 