### PR TITLE
Add info on GitHub permissions, fix #195

### DIFF
--- a/how-to/editor-in-chief-guide.md
+++ b/how-to/editor-in-chief-guide.md
@@ -90,9 +90,18 @@ organization.
 
 Once the package initial checks are complete, and it is determined that
 the package is in scope for pyOpenSci review, the Editor in Chief will assign an
-editor to the review issue. The editor will begin the process of finding reviewers
-for the package. [Check out the editor guide for more information on this process](editors-guide.md)
-
+editor to the review issue.
+This may involve finding a new editor
+as described in the [onboarding guide](onboarding-guide.md).
+If you as Editor in Chief do recruit a new editor,
+be sure to complete all the onboarding steps described
+[here](onboarding-a-new-editor) so that the new editor
+has everything they need to manage the review,
+such as GitHub permissions and access to the relevant channels
+in the pyOpenSci Slack team.
+It is the editor that will now begin the process of finding reviewers
+for the package.
+[Check out the editor guide for more information on this process](editors-guide.md)
 
 ```{admonition} Diversity in the editorial & reviewer  team is important
 :class: important
@@ -102,7 +111,7 @@ editorial team comprised of an editor + 2 reviewers from diverse backgrounds.
 
 As you select an editor (and guide that editor in finding reviewers),
 ensure that there is diversity
-in the team supporting package review. [Specifically reviewers and the editor should have a mix of gender-identities whenever possible](reviewer-diversity). pyOpenSci [also supports mentoring new reviewers and editors if needed!](review-mentorshipreview-mentorship)
+in the team supporting package review. [Specifically reviewers and the editor should have a mix of gender-identities whenever possible](reviewer-diversity). pyOpenSci [also supports mentoring new reviewers and editors if needed!](review-mentorship)
 
 ```
 

--- a/how-to/editor-in-chief-guide.md
+++ b/how-to/editor-in-chief-guide.md
@@ -91,7 +91,7 @@ organization.
 Once the package initial checks are complete, and it is determined that
 the package is in scope for pyOpenSci review, the Editor in Chief will assign an
 editor to the review issue.
-This may involve finding a new editor
+This may involve finding a new (guest) editor
 as described in the [onboarding guide](onboarding-guide.md).
 If you as Editor in Chief do recruit a new editor,
 be sure to complete all the onboarding steps described
@@ -99,9 +99,9 @@ be sure to complete all the onboarding steps described
 has everything they need to manage the review,
 such as GitHub permissions and access to the relevant channels
 in the pyOpenSci Slack team.
-It is the editor that will now begin the process of finding reviewers
+The editor will now begin the process of finding reviewers
 for the package.
-[Check out the editor guide for more information on this process](editors-guide.md)
+[Check out the editor guide for more information on the process that an editor follows](editors-guide.md)
 
 ```{admonition} Diversity in the editorial & reviewer  team is important
 :class: important

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -117,6 +117,7 @@ Best,
 [your-name-here], on behalf of the pyOpenSci Editorial Board
 ```
 
+(onboarding-a-new-editor)=
 ## Onboarding a new editor
 
 To onboard a new editor:
@@ -147,9 +148,13 @@ the `title:` yaml element and update `contributor_type:` as see below:
 
 * If they haven't already done, ask the new editor turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
 
+* Give editors permissions they will need on GitHub to manage reviews:
+  * For ad-hoc guest editors: invite the editor to the `software-submission` repository
+    with "maintain" permissions.
+  * For new editors (not ad-hoc): invite editors to the pyOpenSci GitHub organzation
+    as a member of the [`editorial-board`](https://github.com/orgs/pyOpenSci/teams/editorial-board) team. This will give them appropriate permissions and allow them to get team-specific notifications.
+
 <!-- do we need this?
-* Invite editors to the pyOpenSci GitHub organization as member, as a member of the [`editors` team](https://github.com/orgs/pyopensci/teams/editors).
-This will give them appropriate permissions and allow them to get team-specific notifications.
 * Editors need access to the AirTable database of software review.
 * * In the Slack workspace they need to be added to the editors team so that `@editors` will ping them too.
  -->

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -146,7 +146,7 @@ the `title:` yaml element and update `contributor_type:` as see below:
 
 * Next work with the new editor to create a blog post introducing them which will get [posted on the pyOpenSci blog](https://www.pyopensci.org/blog).
 
-* If they haven't already done, ask the new editor turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
+* If they haven't already done, ask the new editor to turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
 
 * Give editors permissions they will need on GitHub to manage reviews:
   * For ad-hoc guest editors: invite the editor to the `software-submission` repository


### PR DESCRIPTION
- Add info on giving new editors GitHub permissions in onboarding-guide.md.
- Add links to onboarding guide from editor-in-chief guide.
- Also fix a link to review-mentorship in editor-in-chief.md