### PR TITLE
Fix HTML-Proofer failure for 2i2c documentation

### DIFF
--- a/partners/pangeo.md
+++ b/partners/pangeo.md
@@ -29,4 +29,4 @@ defined by the Pangeo community.
         * [Tutorial on using Dask and lazy loading]( https://tutorial.dask.org/01_dataframe.html )
 
 * **Use existing data reading and writing libraries rather than creating your own:** In general, your package should use existing libraries for reading and writing data (e.g. xarray, pandas, geopandas, or the libraries those are built on like Zarr, GDAL, pyarrow, etc.) and should not include its own custom code for read/write data operations. These tools already read and write a variety of file types to a variety of file systems that are important to Pangeo users, including Cloud Object storage.
-[See: 2i2c documentation for more on cloud native file format support.](https://docs.2i2c.org/en/latest/data/cloud.html#cloud-native-formats)
+[See: 2i2c documentation for more on cloud native file format support.](https://docs.2i2c.org/data/cloud/#cloud-native-formats)


### PR DESCRIPTION
This pull request fixes the failing [HTML-proofer check](https://github.com/pyOpenSci/software-peer-review/actions/runs/4994719748/jobs/8945670685) currently happening on main.

Thanks for considering it. :) 