### PR TITLE
Remove implementation suggestions from checks

### DIFF
--- a/appendices/editor-in-chief-checks.md
+++ b/appendices/editor-in-chief-checks.md
@@ -15,7 +15,7 @@ below.
 - [ ] **Documentation** The package has sufficient online documentation to allow us to evaluate package function and scope *without installing the package*. This includes:
   - [ ] User-facing documentation that overviews how to install and start using the package.
   - [ ] Short tutorials that help a user understand how to use the package and what it can do for them.
-  - [ ] API documentation (documentation for your code's functions, classes, methods and attributes): this includes clearly written docstrings with variables defined using a standard docstring format. *We suggest using the [Numpy](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) docstring format*.
+  - [ ] API documentation (documentation for your code's functions, classes, methods and attributes): this includes clearly written docstrings with variables defined using a standard docstring format.
 - [ ] Core GitHub repository Files
   - [ ] **README** The package has a `README.md` file with clear explanation of what the package does, instructions on how to install it, and a link to development instructions.
   - [ ] **Contributing File** The package has a `CONTRIBUTING.md` file that details how to install and contribute to the package.

--- a/appendices/editor-in-chief-checks.md
+++ b/appendices/editor-in-chief-checks.md
@@ -23,7 +23,7 @@ below.
   - [ ] **License** The package has an [OSI approved license](https://opensource.org/licenses).
 NOTE: We prefer that you have development instructions in your documentation too.
 - [ ] **Issue Submission Documentation** All of the information is filled out in the `YAML` header of the issue (located at the top of the issue template).
-- [ ] **Automated tests** Package has a testing suite and is tested via GitHub actions or another Continuous Integration service.
+- [ ] **Automated tests** Package has a testing suite and is tested via a Continuous Integration service.
 - [ ] **Repository** The repository link resolves correctly.
 - [ ] **Package overlap** The package doesn't entirely overlap with the functionality of other packages that have already been submitted to pyOpenSci.
 - [ ] **Archive** (JOSS only, may be post-review): The repository DOI resolves correctly.


### PR DESCRIPTION
It feels like this isn't the right place to be recommending specific implementation details for these checks, and this reduces the amount of text here a bit to make it easier to follow