### PR TITLE
Fix: remove language around adding package and contribs to website

### DIFF
--- a/appendices/package-approval-template.md
+++ b/appendices/package-approval-template.md
@@ -11,8 +11,6 @@ There are a few things left to do to wrap up this submission:
 - [ ] Tag and create a release to create a Zenodo version and DOI.
 - [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/issue-number)`.
 - [ ] Please fill out the [post-review survey](https://forms.gle/BLGVCfUdiJHS5YJY7). All maintainers and reviewers should fill this out.
-- [ ] Add <package-name> to the pyOpenSci website. <maintainer-name>, please open a pr to update [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/packages.yml): to add your package and name to the list of contributors.
-- [ ] <reviewers-and-maintainers> if you have time and are open to being listed on our website, please add yourselves to [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) via a pr so we can list you on our website as contributors!
 
 <IF JOSS SUBMISSION>
 It looks like you would like to submit this package to JOSS. Here are the next steps:


### PR DESCRIPTION
A small PR that fixes language for the final step of review. We now have an automated workflow that adds people to the website and adds the package as well. it's better to use the automated workflow for consistency but also it's less work for wrapping up a review!