### PR TITLE
Fix: update editor steps to include reviewer info & update checklist

### DIFF
--- a/appendices/package-approval-template.md
+++ b/appendices/package-approval-template.md
@@ -31,7 +31,9 @@ Please complete the final steps to wrap up this review. Editor, please do the fo
 - [ ] Make sure that the maintainers filled out the [post-review survey](https://forms.gle/BLGVCfUdiJHS5YJY7)
 - [ ] Invite the maintainers to submit a blog post highlighting their package. Feel free to use / adapt [language found in this comment](https://github.com/pyOpenSci/software-submission/issues/93#issuecomment-1591687581) to help guide the author.
 - [ ] Change the status tag of the issue to `6/pyOS-approved6 🚀🚀🚀`.
+- [ ] Invite the package maintainer(s) and both reviewers to slack if they wish to join.
 - [ ] If the author submits to JOSS, please continue to update the labels for JOSS on this issue until the author is accepted (do not remove the `6/pyOS-approved` label). Once accepted add the label `9/joss-approved` to the issue. Skip this check if the package is not submitted to JOSS.
+- [ ] If the package is JOSS-accepted please add the JOSS doi to the YAML at the top of the issue.
 
 ---
 

--- a/conf.py
+++ b/conf.py
@@ -80,7 +80,8 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "github_url": "https://github.com/pyOpenSci/software-peer-review",
     "twitter_url": "https://twitter.com/pyopensci",
-    "footer_items": ["copyright"],
+    "footer_start": ["copyright"],
+    "footer_end": [],
 }
 
 # html_theme_options["analytics"] = {

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -208,7 +208,7 @@ Diversity is core to the pyOpenSci mission. As such it's important to have an
 editorial team comprised of an editor + 2 reviewers from diverse backgrounds.
 
 In your search for reviewers, please ensure ensure that there is diversity
-in the team supporting package review. [Specifically both reviewers should have different backgrounds and different gender-identities whenever possible](reviewer-diversity). pyOpenSci [supports mentoring new reviewers if needed!](review-mentorshipreview-mentorship)
+in the team supporting package review. Specifically both reviewers should have [different backgrounds and different gender-identities](reviewer-diversity) whenever possible. pyOpenSci [supports mentoring new reviewers if needed!](review-mentorship)
 
 [Read our finding reviewers guide for more on finding reviewers.](finding-reviewers)
 ```

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -176,10 +176,30 @@ we are using our volunteer reviewer time effectively.
 structure, request changes before assigning reviewers.**
 ```
 
-### ✔️ 3. Identify Python package reviewers
+### ✔️ 3. Identify scientific Python package reviewers
 
-Within **one week of responding to the issue as the editor**, identify two people to
-review the Python package.
+Each review should have at least 2 reviewers.
+
+- One reviewer should have expertise in both Python and the scientific domain related to the package submitted.
+- The second reviewer can be a more generally focused on the package's usability, accessibility and packaging infrastructure.
+
+A review consisting of a domain expert and a Pythonista is ideal as it provides two distinct perspectives for review. Further it can often be difficult to find two people with both the specific domain expertise AND packaging expertise.
+
+#### Finding package reviewers
+
+Often times, finding reviewers for a package can be the trickiest part
+of the review process. Expect this to take a bit of time. [Check out this page for tips related to finding reviewers.](finding-reviewers)
+
+If you can, try to find two people to serve as reviewers within **two weeks
+of responding to the issue as the editor**. If it takes longer, as
+often does, make a point to keep the author posted on the issue
+as you continue your search. You may add language such as:
+
+> Hey, @authorGithubHandle I just wanted to drop in to let you know that I'm searching for reviewers for your package. It may take a bit more time.
+
+This type of communication just lets the author know that the process is
+moving forward. Even if it takes longer to find reviews, authors generally
+appreciate the communication and understand it's a volunteer-lead process.
 
 ```{admonition} Diversity in the editorial & reviewer  team is important
 :class: important
@@ -210,10 +230,6 @@ moving.
 2. the review deadline date.
 
 - Change the label on the issue to `3/reviewer(s)-assigned`
-
-```{note}
-[Click here for more information about finding reviewers for a package.](finding-reviewers)
-```
 
 ```{warning}
 Make sure to ask the reviewers for their preferred means of contact, or a reliable way to get in touch with them.
@@ -309,7 +325,10 @@ Once the package has been accepted through the review process:
 
 - Don't forget to change the status tag of the issue to `6/pyOS-approved` 🚀🚀🚀`.
 - If the package moves on to JOSS - be sure to continue to update the labels to track the JOSS review process (but do NOT remove the `6/pyOS-approved` label).
-- Update the YAML at the top of the issue with the version of the package that was approved, Zenodo DOI for the approved version and the date approved.
+- Update the YAML at the top of the issue with the:
+  - version of the package that was approved,
+  - Zenodo DOI for the approved version and
+  - the date approved.
 
 ```markdown
 Archive: UPDATE-THIS-WITH-A-ZENODO-ARCHIVE-BADGE-TBD


### PR DESCRIPTION
This PR does a few things. 

1. it fixes a minor footer pydata sphinx theme deprecation
2. it adds some language about the types of reviewers we ideally want for each package
3. it updates the checklist at the end to include inviting folks to slack. 

i'd love a review from 1-2 members our of @pyOpenSci/editorial-board if that is possible!! many thanks y'all!!