### PR TITLE
Fix: add favicon and add blocks to author guide

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -46,6 +46,13 @@ html_js_files = ["matomo.js"]
 
 # Theme options
 html_theme_options = {
+    "favicons": [
+      {
+         "rel": "icon",
+         "sizes": "16x16",
+         "href": "https://www.pyopensci.org/images/favicon.ico",
+      },
+   ],
     "announcement": "<p><a href='https://www.github.com/pyopensci/software-submission/'>Submit Your Python Package for Peer Review!</a></p>",
     "external_links": [
         {

--- a/how-to/author-guide.md
+++ b/how-to/author-guide.md
@@ -1,4 +1,4 @@
-# Guide for Python Open Source Maintainers and Authors
+# Peer Review Guide for Python Open Source Authors / Authors
 
 ```{toctree}
 :hidden:
@@ -22,7 +22,77 @@ Finding Reviewers <finding-reviewers>
 
 Are you considering submitting a package for review with pyOpenSci? You've
 come to the right place! Below you will find the steps that you need to follow
-to submit a package to pyOpenSci for peer review.
+to submit a package to pyOpenSci for peer review along with some additional resources that you may find useful.
+
+## Peer review resources
+
+::::{grid} 1 2 3 3
+:class-container: text-center
+:gutter: 3
+
+:::{grid-item-card} <i class="fa-solid fa-crosshairs"></i> Package scope
+:link: ../about/package-scope
+:link-type: doc
+:class-header: bg-light
+
+Learn about the requirements and scope of packages that pyOpenSci reviews.
++++
+<i class="fa-solid fa-link"></i> Learn more
+:::
+
+:::{grid-item-card} <i class="fa-solid fa-magnifying-glass"></i> How review works
+:link: ../our-process/how-review-works
+:link-type: doc
+:class-header: bg-light
+
+We review packages openly using GitHub Issues.
++++
+<i class="fa-solid fa-link"></i> Learn more
+:::
+
+:::{grid-item-card}  <i class="fa-solid fa-timeline"></i> Review timeline
+:link: ../our-process/review-timeline
+:link-type: doc
+:class-header: bg-light
+
+Curious about the general timeline for pyOpenSci reviews?
++++
+<i class="fa-solid fa-link"></i> Learn more here
+:::
+
+
+:::{grid-item-card} Review Guidelines & Policies
+:link: ../our-process/policies
+:link-type: doc
+:class-header: bg-light
+
+Read about our peer review policies.
++++
+<i class="fa-solid fa-link"></i> Learn more
+:::
+
+
+:::{grid-item-card} <i class="fa-solid fa-handshake-angle"></i></i> Need packaging guidance?
+:link: https://www.pyopensci.org/python-package-guide/
+:link-type: doc
+:class-header: bg-light
+
+If you want to learn more about packaging best practices, you can check out our packaging guide.
++++
+<i class="fa-solid fa-arrow-up-right-from-square"></i> Go there now
+:::
+
+:::{grid-item-card} <i class="fa-solid fa-clipboard-question"></i> Questions?
+:link: https://pyopensci.discourse.group/c/review-process/7
+:link-type: doc
+:class-header: bg-light
+
+If you have questions about our process or packaging in general, please ask them on our discourse! We are here to help you.
++++
+<i class="fa-solid fa-arrow-up-right-from-square"></i> Go there now
+:::
+::::
+
 
 Before you begin this process, [please be sure to read the review process guidelines](../our-process/policies).
 

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -1,4 +1,4 @@
-# pyOpenSci Guide for Peer Review Editors
+# pyOpenSci Software Review Editor Guide
 
 <!--
 ```{note}

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -188,7 +188,7 @@ Diversity is core to the pyOpenSci mission. As such it's important to have an
 editorial team comprised of an editor + 2 reviewers from diverse backgrounds.
 
 In your search for reviewers, please ensure ensure that there is diversity
-in the team supporting package review. [Specifically both reviewers should have different backgrounds and different gender-identities whenever possible](reviewer-diversity). pyOpenSci [supports mentoring new reviewers if needed!](review-mentorshipreview-mentorship)
+in the team supporting package review. [Specifically both reviewers should have different backgrounds and different gender-identities whenever possible](reviewer-diversity). pyOpenSci [supports mentoring new reviewers if needed!](review-mentorship)
 
 [Read our finding reviewers guide for more on finding reviewers.](finding-reviewers)
 ```

--- a/index.md
+++ b/index.md
@@ -53,7 +53,7 @@ Learn about the scope of the packages that we review.
 [Click to learn more »](about/package-scope)
 :::
 
-:::{grid-item-card} {octicon}`code-square;1.5em;sd-mr-1`Maintainers Guide
+:::{grid-item-card} {octicon}`code-square;1.5em;sd-mr-1`Authors Guide
 :link: how-to/author-guide
 :link-type: doc
 :class-header: bg-light


### PR DESCRIPTION
this pr adds boxes at the top of the author guide to other core peer review resources. 

NOTE: one issue now is some of these are list below. AND looking at the page i think the steps to initiate a review are not clear. open to additional feedback on making this page a more more clear for people thinking about submitting to us. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206075195584329