### PR TITLE
Fix: fix redirect action for previous

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  build_book:
+  build-book:
     docker:
       - image: cimg/python:3.9
     steps:
@@ -24,4 +24,4 @@ workflows:
   version: 2
   build_book:
     jobs:
-      - build_book
+      - build-book

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -1,11 +1,17 @@
-name: Book Preview
-
+name: CircleCI artifacts redirector
 on: [status]
+
+concurrency:
+  group: docs-preview-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
-    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
+    # For testing this action on a fork, remove the "github.repository =="" condition.
+    if: "github.event.context == 'ci/circleci: build-book'"
+    permissions:
+      statuses: write
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
@@ -13,6 +19,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/html/index.html
-          circleci-jobs: build_book
-          job-title: Click to preview rendered book
+          circleci-jobs: build-book
+          job-title: View rendered book here!


### PR DESCRIPTION
This should fix the CI action that creates a easy redirect to the built guidebook packages
it adds
* the needed circle ci token (which is at the organization level now and scoped for just the repos it needs access to
* updated the build to build-book (no underscore)
* setups up concurrency to avoid duplicate builds