### PR TITLE
Fix: pin pydata sphinx to get left side bar nav back

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydata-sphinx-theme
+pydata-sphinx-theme==0.14.4
 myst-nb
 sphinx
 sphinx-autobuild


### PR DESCRIPTION
The pydata sphinx theme fix has not been implemented yet. as such this pins the version so our left side nav works again!