### PR TITLE
ENH: updates to editor & reviewer onboarding pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,7 +16,9 @@ author = "pyOpenSci Community"
 # Get the latest Git tag - there might be a prettier way to do this but...
 try:
     release_value = (
-        subprocess.check_output(["git", "describe", "--tags"]).decode("utf-8").strip()
+        subprocess.check_output(["git", "describe", "--tags"])
+        .decode("utf-8")
+        .strip()
     )
     release_value = release_value[:4]
 except subprocess.CalledProcessError:
@@ -38,6 +40,7 @@ extensions = [
     "sphinx_sitemap",
     "sphinxext.opengraph",
     "sphinx_copybutton",
+    "sphinx.ext.todo",
 ]
 
 # colon fence for card support in md

--- a/how-to/author-guide.md
+++ b/how-to/author-guide.md
@@ -15,8 +15,8 @@ Triage Team Guide <review-triage-team>
 :hidden:
 :caption: Onboarding Editors & Reviewers
 
-Onboarding Editors & Reviewers <onboarding-guide>
-Finding Reviewers <finding-reviewers>
+Finding & Onboarding Editors <onboarding-guide>
+Finding & Onboarding Reviewers <finding-reviewers>
 ```
 
 Are you considering submitting a package for review with pyOpenSci? You've

--- a/how-to/finding-reviewers.md
+++ b/how-to/finding-reviewers.md
@@ -22,7 +22,7 @@ When the above doesn't work and you still need to find a reviewer:
 * Post in the pyOpenSci Slack `#software-review` channel.
 * Look for users of the package or the data source/upstream service the
   package connects to (via their opening issues in the repository, starring
-  it, citing it in papers, talking about it on Twitter).
+  it, citing it in papers, talking about it on social media).
 * Search for authors/maintainers of related packages on [PyPI](https://pypi.org/search/).
 * Coordinate with our Community Manager to post a call for reviewers on our
   pyOpenSci social channels.
@@ -51,7 +51,7 @@ website, social media profiles).
 Try to balance your sense of the potential reviewer’s experience against the
 complexity of the package.
 
-* **Diversity** - if you have two reviewers, both shouldn’t be cis white males.
+* **Diversity** - if you have two reviewers, only one should be a cis white male.
 * **Openness** - reviewers should also have demonstrated interest in open
   source or Python community activities, although blind emailing is fine.
 
@@ -84,12 +84,12 @@ for usability.
 If a new reviewer is interested in becoming a reviewer but would like some
 support, do the following:
 
-1. Reach out to the **editor in chief** & **peer review lead** to let them
+1. Reach out to the **Editor in Chief** & **Peer Review Lead** to let them
    know that you have a reviewer that would like to work with a mentor.
 2. They will then post in the `#software-review` channel to see if anyone is
    available to provide support to the new reviewer.
 3. If you don't get any responses from the post above, reach out to our
-   community manager who will try to find someone to fill the mentorship role!
+   Community Manager who will try to find someone to fill the mentorship role!
 
 ### Once a Mentor is Identified
 

--- a/how-to/finding-reviewers.md
+++ b/how-to/finding-reviewers.md
@@ -51,7 +51,7 @@ website, social media profiles).
 Try to balance your sense of the potential reviewer’s experience against the
 complexity of the package.
 
-* **Diversity** - if you have two reviewers, only one should be a cis white male.
+* **Diversity:** Try to find reviewers from different backgrounds and gender identities. For example, if you have two reviewers, only one should be a cis white male.
 * **Openness** - reviewers should also have demonstrated interest in open
   source or Python community activities, although blind emailing is fine.
 

--- a/how-to/finding-reviewers.md
+++ b/how-to/finding-reviewers.md
@@ -1,24 +1,44 @@
-# Reviewer Resources
+# Finding Reviewers
+
+Sometimes the most challenging part of our pyOpenSci open peer review process
+is finding reviewers. This page provides tips and tricks to help you find the
+right people to review a scientific Python package.
 
 ## Where to Look for Reviewers?
 
-As a (guest) editor, you can find reviewers through:
-* Suggestions made by the submitter(s) (although submitters may have a narrow view of the types of expertise needed. We suggest not using more than one of the suggested reviewers).
-* Authors of existing [pyOpenSci packages](https://www.pyopensci.org/python-packages/).
-* Other [contributors to pyOpenSci](https://www.pyopensci.org/our-community/).
+As an editor, you can find reviewers through:
 
-When these sources of information are not enough:
+* Suggestions made by the submitting package authors. We suggest only using
+  one of the suggested reviewers if this is the case.
+* Authors of existing [pyOpenSci packages](https://www.pyopensci.org/python-packages/).
+* Other [pyOpenSci contributors](https://www.pyopensci.org/our-community/).
+
+When the above doesn't work and you still need to find a reviewer:
+
+* Check our reviewer sign-up spreadsheet for names of people who have already
+  volunteered to review for pyOpenSci. The link for this document is pinned to
+  the pyOpenSci Slack `#private-editorial-channel`.
 * Ping other editors for ideas.
-* Look for users of the package or the data source/upstream service the package connects to (via their opening issues in the repository, starring it, citing it in papers, talking about it on Twitter).
-* You can also search for authors/maintainers of related packages on [PyPI](https://pypi.org/search/).
-* Post on Twitter and ensure pyOpenSci retweets your post.
+* Post in the pyOpenSci Slack `#software-review` channel.
+* Look for users of the package or the data source/upstream service the
+  package connects to (via their opening issues in the repository, starring
+  it, citing it in papers, talking about it on Twitter).
+* Search for authors/maintainers of related packages on [PyPI](https://pypi.org/search/).
+* Coordinate with our Community Manager to post a call for reviewers on our
+  pyOpenSci social channels.
+
+:::{important}
+
+If you do a reviewer search, please be sure to have new reviewers first sign
+up using our [reviewer signup form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform).
+:::
 
 ## Criteria for Choosing Reviewers
 
 Here are criteria to keep in mind when choosing a reviewer. You might need to
-piece this information together by searching `PyPI`, `Conda` / `Conda-forge` and
-the potential reviewer’s GitHub page and general online presence (personal
-website, Twitter).
+piece this information together by searching `PyPI`, `Conda` / `Conda-forge`
+and the potential reviewer’s GitHub page and general online presence (personal
+website, social media profiles).
 
 * Has not reviewed a package for us within the last 6 months.
 * Some package development / contribution experience.
@@ -26,28 +46,54 @@ website, Twitter).
 * No [conflicts of interest](coi).
 
 (reviewer-diversity)=
-### Reviewer diversity should be prioritized
-Try to balance your sense of the potential reviewer’s experience against the complexity of the package.
+### Reviewer Diversity Should Be Prioritized
+
+Try to balance your sense of the potential reviewer’s experience against the
+complexity of the package.
 
 * **Diversity** - if you have two reviewers, both shouldn’t be cis white males.
-* **Openness** - reviewers should also have demonstrated interest in open source or Python community activities, although blind emailing is fine.
+* **Openness** - reviewers should also have demonstrated interest in open
+  source or Python community activities, although blind emailing is fine.
 
 Each submission should be reviewed by _two_ package reviewers. Although it is
-fine for one of them to have less package development experience and more domain
-knowledge, the review should not be split into two parts. Both reviewers need to review
-the package comprehensively, from their particular perspectives. In
-general, at least one reviewer should have prior reviewing experience, and of
-course inviting one new reviewer expands our pool of reviewers.
+fine for one of them to have less package development experience and more
+domain knowledge, the review should not be split into two parts. Both
+reviewers need to review the package comprehensively, from their particular
+perspectives. In general, at least one reviewer should have prior reviewing
+experience, and of course inviting one new reviewer expands our pool of
+reviewers.
 
-Reviewers should ideally have some subject matter expertise associated
-with the package functionality. It is ok and even welcome if one reviewer has
-more technical expertise and the other focuses on usability and is less technical.
-Read through the Guidelines for Reviewers Section to learn more about finding and
-selecting reviewers.
+Reviewers should ideally have some subject matter expertise associated with
+the package functionality. It is ok and even welcome if one reviewer has more
+technical expertise and the other focuses on usability and is less technical.
+Read through the Guidelines for Reviewers Section to learn more about finding
+and selecting reviewers.
 
 (review-mentorship)=
-```{note}
-PyOpenSci has been piloting a new reviewer mentorship program where we pair a
-new reviewer with someone in the community with previous review experience. If
-a new reviewer is interested in this, get in touch with the **editor in chief**.
-```
+## Peer Review Mentorship
+
+pyOpenSci encourages those who are newer to review to become involved in our
+open peer review process. As such, we offer a reviewer mentorship program
+where we pair a new reviewer with someone in the community that has previous
+review experience.
+
+It is useful for reviewers to not only review the technical content of a
+package, but also to review the documentation and package installation process
+for usability.
+
+If a new reviewer is interested in becoming a reviewer but would like some
+support, do the following:
+
+1. Reach out to the **editor in chief** & **peer review lead** to let them
+   know that you have a reviewer that would like to work with a mentor.
+2. They will then post in the `#software-review` channel to see if anyone is
+   available to provide support to the new reviewer.
+3. If you don't get any responses from the post above, reach out to our
+   community manager who will try to find someone to fill the mentorship role!
+
+### Once a Mentor is Identified
+
+1. Invite the new reviewer to our pyOpenSci Slack.
+2. Start a private DM group chat with the new reviewer and the mentor(s) so
+   they are introduced.
+3. Let the review proceed from there.

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -26,37 +26,48 @@ Chief. In the future we hope to find someone with interest in leading peer revie
 
 ## Where to find new editors
 
-As we build our pyOpenSci community our pool of potential editors will grow.
-A few options to consider include:
+The pyOpenSci community continues to grow rapidly, and as such we now have a much stronger reach on social media than ever before. While you will collaborate closely with the pyOpenSci Community Manager to recruit editors through social media campaigns, also consider the following sources:
+
 * Contributors who have reviewed for pyOpenSci
 * Contributors who have submitted a package to pyOpenSci
 * Contributors who have served as a guest editor
 * Colleagues that you know who have reviewed for JOSS or rOpenSci who have Python expertise
 
+pyOpenSci maintains a database of contributors, and the Community Manager can assist you in identifying individuals who may be a good fit. Please reach out to them either in a private Slack message or via email, at [media@pyopensci.org](mailto:media@pyopensci.org). 
+
+
 ## Starting the editorial search
 
-To begin, start your search well in advance of when you think you may need new
-editor(s). When you begin your search, start with the existing editorial team.
-See if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private channels on Slack as follows:
+In an ideal world, you’d be able to start your search well in advance of when you think you may need to expand the editorial team. However, due to the influx of new packages, this isn’t always possible. As such, when you begin your search, start with the existing editorial team as well as the pyOpenSci Community Manager.
 
-* Start a private channel for discussion. This ensures there is not a visible
-history in a public channel that a new editor may see in the future (this could
-be awkward for someone to see!).
-* Ping editors to be sure they get a notification as this is an important topic.
-* Wait for a majority of editors to chime in before inviting someone. Provide
-editors one week to respond on slack.
+### The Editorial Team
+It’s helpful to first check with the existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board), in order to see if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private Slack channel as follows:
+
+* Start a private channel for discussion. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
+* Ping editors using @here to be sure they get a notification, as this is an important topic.
+* Wait for a majority of editors to chime in before inviting someone. Provide editors one week to respond on Slack.
+
+### The pyOpenSci Community Manager
+The Community Manager is available to assist with editor recruitment at any stage in the process, even if it’s before you think you might need editors. Standard recruitment involves targeted social media posts [(similar to this)](https://fosstodon.org/@pyOpenSci/112497485980274296), a blog post, and call-outs in both our monthly and weekly newsletters. To kick off this process, or to request additional ideas for recruitment, reach out to the Community Manager via private message in Slack to let them know:
+
+* That you’re looking for editors!
+* Which type(s) of editors you’re looking for (full, guest).
+* Any specific domains or technical skills you need an editor to have, or if it’s a general call for editors.
+* Any specific packages that need an editor.
+* Any additional promotion you’d like, beyond social media posts, a blog post, and newsletter updates.
+
+```{note}
+pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
+```
 
 ## Experience required to be an editor
 
 We prefer that editors have some experience with reviewing software. This experience
 could come from a previous review they worked on with pyOpenSci, rOpenSci or JOSS.
 
-If they do not have experience as may be the case in the early months or establishing
-a robust editorial board, we  offer a "mentorship" process. Editor mentorship
-is where someone with existing editorial experience, mentors the new editor
-through their first review(s).
+If they do not have experience, as may be the case when we receive a large number of package submissions while also establishing a robust editorial board, we do offer a "mentorship" process. Editor mentorship is where someone with existing editorial experience mentors the new editor through their first review(s).
 
-A new editor will be considered "guest" for the first 3 months of their tenure
+A new editor will be considered a guest editor for the first 3 months of their tenure
 and/or until they have completed their first review. Once they have a completed
 a review they can be considered to be a full editor as deemed appropriate by the
 software review lead and the current editorial board.
@@ -69,8 +80,10 @@ type of situation). Examples of when this might happen include:
 * if there a conflict of interest between a package submitter and the editorial team (e.g. a close colleague of everyone on the team)
 * if the editorial board is at capacity handling the current review load
 
-In this case, you may consider using our internal reviewer signup list to see
-if someone who signed up to be a reviewer might want to serve as an editor.
+In this case, you may consider using our internal reviewer signup list to see if someone who signed up to be a reviewer might want to serve as an editor.
+
+## Process for inviting a first-time community member
+
 
 ## Process for inviting a new editor
 

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -1,139 +1,196 @@
-# Onboarding New Editors and Reviewers
+# Onboarding New Editors
 
-The pyOpenSci open peer review process is supported by volunteer editors. Here we discuss processes for onboarding new editors.
+The pyOpenSci open peer review process is driven and led by volunteer editors
+and reviewers. Finding new volunteers to take on editorial and reviewer roles
+can sometimes be the trickiest part of the review process. However, we have
+resources available to help you in that effort!
 
-The success of our peer review process is dependent upon a
-well-balanced editorial board. Our board needs to have combined expertise in:
+Below we discuss processes for finding and onboarding new volunteers to our
+peer review process.
 
-* A suite of specific science domains that fall within the scope of our peer review process
-* Technical expertise in Python packaging.
-* Awareness of the importance of documentation and package usability.
-* Awareness of the importance of CI / test suites to ensure robust software development.
+## About the Editorial Board
 
-## Recruiting new editors
+The success of our peer review process is dependent upon a well-balanced
+editorial board. Our board needs to have combined expertise in:
 
-Recruiting new editors and maintaining a sufficient and well-balanced editorial
-board is the responsibility of the software review lead (position to be
-defined) with support and advice from the editorial board.
+* A suite of specific science domains that fall within the scope of our peer
+  review process
+* Technical expertise in Python packaging
+* Awareness of the importance of documentation and package usability
+* Awareness of the importance of CI / test suites to ensure robust software
+  development
 
-```{note}
-pyOpenSci is a newly restructured organization. While we've been performing peer
-review for almost 4 years, we are now beginning to formalize our process thanks to
-funding support from the Sloan foundation. In these early months, this software
-review lead role will be completed largely by the Executive Director with support from the Editor in
-Chief. In the future we hope to find someone with interest in leading peer review for pyOpenSci
-```
+We also strive to ensure our editorial team is diverse and comprised of people
+from different backgrounds, cultures, genders, and domains.
 
-## Where to find new editors
+### Types of Editors
 
-The pyOpenSci community continues to grow rapidly, and as such we now have a much stronger reach on social media than ever before. While you will collaborate closely with the pyOpenSci Community Manager to recruit editors through social media campaigns, also consider the following sources:
+#### New Editors Start as "Guests"
 
-The pyOpenSci community continues to grow rapidly, and as such we now have a much stronger reach on social media than ever before. While you will collaborate closely with the pyOpenSci Community Manager to recruit editors through social media campaigns, also consider the following sources:
+A new editor will be considered a guest editor for the first 3 months of their
+tenure and/or until they have completed their first review. Once they have
+completed a review, they can be considered a full editor as deemed appropriate
+by the software review lead and the current editorial board.
 
-* Contributors who have reviewed for pyOpenSci
-* Contributors who have submitted a package to pyOpenSci
-* Contributors who have served as a guest editor
-* Colleagues that you know who have reviewed for JOSS or rOpenSci who have Python expertise
+#### Adhoc Guest Editors
 
-pyOpenSci maintains a database of contributors, and the Community Manager can assist you in identifying individuals who may be a good fit. Please reach out to them either in a private Slack message or via email, at [media@pyopensci.org](mailto:media@pyopensci.org). 
+Adhoc editors are editors with specific skill sets that are brought in to lead
+a single review. Examples of when there might be a need for an ad-hoc editor
+include:
+
+* If there is a conflict of interest between a package submitter and the
+  editorial team (e.g., a close colleague of everyone on the team)
+* If the editorial board is at capacity handling the current review load
+* If a very specialized skill set is needed (in a one-off type of situation)
+
+In this case, you may consider using our internal reviewer sign-up list to see
+if someone who signed up to be a reviewer might want to serve as an editor.
+
+### Experience Required to Be an Editor
+
+We prefer that editors have some experience with reviewing software. This
+experience could come from a previous review they worked on with pyOpenSci,
+rOpenSci, or JOSS.
+
+### Editorial Mentorship
+
+If a potential volunteer does not have prior software editorial experience, we
+offer a **mentorship process**. Editor mentorship is where someone with
+existing editorial experience mentors the new editor through their first
+review(s).
+
+### Recruiting New Editors
+
+Recruiting new editors and maintaining a sufficient and well-balanced
+editorial board is the responsibility of the
+[Software Review Lead](https://www.pyopensci.org/handbook/governance/structure.html#software-review-lead)
+with support and advice from the editorial board.
+
+:::{note}
+For the time being, the Software Review Lead role is being filled by the
+Executive Director with support from the Editor in Chief as we define our
+process and track the volume of submissions that we need to support. In the
+future, we will find someone with interest in leading peer review for
+pyOpenSci.
+:::
+
+## Where to Find New Editors
+
+Typically the Editor in Chief will work with the Peer Review Lead to find and
+onboard new editors in scientific topical areas where pyOpenSci has existing
+gaps.
+
+You might find good candidates to be an editor through:
+
+* Your professional network: you may know people in a specific domain that
+  might be a good fit to be an editor for pyOpenSci.
+* Our [pyOpenSci list of contributor pool](https://www.pyopensci.org/our-community/index.html#pyopensci-community-contributors) which includes:
+  * Package authors and maintainers who have already submitted a package for
+    review to pyOpenSci
+  * Reviewers who have already led reviews for pyOpenSci
+  * Past guest editors
+* Colleagues that you know who have reviewed for the Journal of Open Source
+  Software (JOSS) or rOpenSci who have Python expertise
+* Community members in the pyOpenSci Slack (please post a call in our
+  `#software-review` channel)
+
+When all of the above fails to return a good new editor candidate, you can find
+support from our pyOpenSci community manager who will post an open call on our
+[social media channels](https://www.pyopensci.org/handbook/community/social.html)
+with a link to our editorial board sign-up form. Using our online network will
+allow you to cast an even wider net to find new interested editors.
+
+:::{todo}
+Ideally, we want to have an online interface for the editors / EiC to own the
+process. When we have a link that will allow the EiC / peer review lead to
+search through something online, we should add it --
+
+pyOpenSci maintains a database of contributors, and the Community Manager can
+assist you in identifying individuals who may be a good fit. Please reach out
+to them either in a private Slack message or via email, at
+[media@pyopensci.org](mailto:media@pyopensci.org).
+:::
 
 
-pyOpenSci maintains a database of contributors, and the Community Manager can assist you in identifying individuals who may be a good fit. Please reach out to them either in a private Slack message or via email, at [media@pyopensci.org](mailto:media@pyopensci.org). 
+
 
 
 ## Starting the editorial search
 
-In an ideal world, you’d be able to start your search well in advance of when you think you may need to expand the editorial team. However, due to the influx of new packages, this isn’t always possible. As such, when you begin your search, start with the existing editorial team as well as the pyOpenSci Community Manager.
+To begin, first post in our `private-editorial-team` slack channel to see if any of our existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board) members can identify past reviewers or other people they know that might be a good editorial candidate.
 
-### The Editorial Team
-It’s helpful to first check with the existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board), in order to see if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private Slack channel as follows:
-In an ideal world, you’d be able to start your search well in advance of when you think you may need to expand the editorial team. However, due to the influx of new packages, this isn’t always possible. As such, when you begin your search, start with the existing editorial team as well as the pyOpenSci Community Manager.
+If there is a discussion around specific candidates, be sure to:
 
-### The Editorial Team
-It’s helpful to first check with the existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board), in order to see if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private Slack channel as follows:
-
-* Start a private channel for discussion. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
+* Start a private group message for discussion about particular candidates. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
 * Ping editors using @here to be sure they get a notification, as this is an important topic.
-* Wait for a majority of editors to chime in before inviting someone. Provide editors one week to respond on Slack.
 
-### The pyOpenSci Community Manager
-The Community Manager is available to assist with editor recruitment at any stage in the process, even if it’s before you think you might need editors. Standard recruitment involves targeted social media posts [(similar to this)](https://fosstodon.org/@pyOpenSci/112497485980274296), a blog post, and call-outs in both our monthly and weekly newsletters. To kick off this process, or to request additional ideas for recruitment, reach out to the Community Manager via private message in Slack to let them know:
 
-* That you’re looking for editors!
-* Which type(s) of editors you’re looking for (full, guest).
-* Any specific domains or technical skills you need an editor to have, or if it’s a general call for editors.
-* Any specific packages that need an editor.
-* Any additional promotion you’d like, beyond social media posts, a blog post, and newsletter updates.
+**IMPORTANT:** Provide up to a week of time for editors to chime in before onboarding a new editor.
 
-```{note}
+### Leverage pyOpenSci social channels to find editors
+
+If you have tried all of the above and still aren't able to find a new
+candidate, then the pyOpenSci Community Manager can assist you by:
+
+* Posting on our social media channels about the position.
+* Writing a [call for editors blog post](https://www.pyopensci.org/blog/pyos-call-for-editors-may-2024.html) about our current editorial needs.
+
+:::{note}
+[See an example here of a post that seeks to recruit editors](https://fosstodon.org/@pyOpenSci/112497485980274296), a blog post, and call-outs in both our monthly and weekly newsletters.
+:::
+
+To get support from the Community Manager in recruiting editors (or reviewers) follow the process below:
+
+* Post in our public `#software-review` slack channel pinging the community manager (`@username`). In your post, include the following details:
+
+  * That you’re looking for editors.
+  * Any specific domains or technical skills you need an editor to have, or if it’s a general call for editors.
+  * Any specific packages that need an editor (include links to a package submission that they would lead if possible).
+
+:::{tip}
+It's helpful to post in our `#software-review` channel rather than
+an individual Direct Message (DM) because:
+
+* It allows other editors to see the type of expertise that you are requesting and that we offer this support from our community manager.
+* It allows other community members who may know of potential editors to see the request and potentially respond.
+:::
+
+Our Community Manager interacts with the broader community and partner communities and as such often interacts with people who may be interested in joining our pyOpenSci review team. The community manager may from time to time meet community members who might make great editors or reviewers. In those cases they will share that information with the current EiC and peer review lead.
+
+:::{todo}
 pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
-```
-* Start a private channel for discussion. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
-* Ping editors using @here to be sure they get a notification, as this is an important topic.
-* Wait for a majority of editors to chime in before inviting someone. Provide editors one week to respond on Slack.
+:::
 
-### The pyOpenSci Community Manager
-The Community Manager is available to assist with editor recruitment at any stage in the process, even if it’s before you think you might need editors. Standard recruitment involves targeted social media posts [(similar to this)](https://fosstodon.org/@pyOpenSci/112497485980274296), a blog post, and call-outs in both our monthly and weekly newsletters. To kick off this process, or to request additional ideas for recruitment, reach out to the Community Manager via private message in Slack to let them know:
 
-* That you’re looking for editors!
-* Which type(s) of editors you’re looking for (full, guest).
-* Any specific domains or technical skills you need an editor to have, or if it’s a general call for editors.
-* Any specific packages that need an editor.
-* Any additional promotion you’d like, beyond social media posts, a blog post, and newsletter updates.
 
-```{note}
-pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
-```
+:::{note}
 
-## Experience required to be an editor
+It is important that a new reviewer or a new editor fill out the appropriate form prior to onboarding.
 
-We prefer that editors have some experience with reviewing software. This experience
-could come from a previous review they worked on with pyOpenSci, rOpenSci or JOSS.
+* [reviewer signup form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform)
+* [editor signup form](https://docs.google.com/forms/d/17NW0P_h8gpmzf7Fr0cAd8aEbIUWPljPfg4d7Rjs1UIE/edit)
 
-If they do not have experience, as may be the case when we receive a large number of package submissions while also establishing a robust editorial board, we do offer a "mentorship" process. Editor mentorship is where someone with existing editorial experience mentors the new editor through their first review(s).
-If they do not have experience, as may be the case when we receive a large number of package submissions while also establishing a robust editorial board, we do offer a "mentorship" process. Editor mentorship is where someone with existing editorial experience mentors the new editor through their first review(s).
+:::
 
-A new editor will be considered a guest editor for the first 3 months of their tenure
-A new editor will be considered a guest editor for the first 3 months of their tenure
-and/or until they have completed their first review. Once they have a completed
-a review they can be considered to be a full editor as deemed appropriate by the
-software review lead and the current editorial board.
 
-## Adhoc guest editors
+## On-boarding a new editor
 
-In some cases you may require a guest editor for a single package (a one-off
-type of situation). Examples of when this might happen include:
+The Editor in Chief, working closely with the Peer Review Lead, is responsible for inviting and onboarding a new editor to our peer review process.
 
-* if there a conflict of interest between a package submitter and the editorial team (e.g. a close colleague of everyone on the team)
-* if the editorial board is at capacity handling the current review load
+When the EIC has identified an editor who is not currently part of the pyOpenSci community, they should:
 
-In this case, you may consider using our internal reviewer signup list to see if someone who signed up to be a reviewer might want to serve as an editor.
+* Extend a Slack invitation to the individual (or ask our Community Manager to do so)
+* Welcome the individual in Slack, and provide them with access to the `#private-editorial-team` and any other channels as needed.
 
-## Process for inviting a first-time community member
+:::{note}
+The Community Manager will ensure that any new member that joins our Slack workspace is welcomed and set up with anything they need in our pyOpenSci Slack workspace.
+:::
 
-### Through the EIC
-
-The Editor in Chief is ultimately the individual responsible for inviting a first-time editor, and when the EIC has identified an editor who is not currently part of the pyOpenSci community, they should:
-
-* Extend a Slack invitation to the individual
-* Welcome the individual in Slack, and provide them with access to the #private-editorial-team and any other channels as needed. 
-
-Both the Community Manager and the Executive Director receive a notification whenever someone joins the Slack group, and the Community Manager will ensure that the new member is welcomed and set up with anything they need for Slack. 
-
-### Through the Community Manager
-
-Although the EIC is responsible for inviting identified editors to the Slack group, it’s common for the Community Manager to interact with prospective community members that may make good reviewers or editors in the future. As such, at the Community Manager’s discretion they may invite members to Slack, and share the member’s background with the EIC, letting them know if the new community member may make a good reviewer or editor.
-
-In addition, the Community Manager will have the new member fill out the [reviewer form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform) or the [editor form](https://docs.google.com/forms/d/17NW0P_h8gpmzf7Fr0cAd8aEbIUWPljPfg4d7Rjs1UIE/edit), as appropriate.
-
-### Through the Executive Director
-
-The Executive Director may invite community members to the Slack group at their discretion, and similar to the Community Manager, may have the member completed the [reviewer form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform) or the [editor form](https://docs.google.com/forms/d/17NW0P_h8gpmzf7Fr0cAd8aEbIUWPljPfg4d7Rjs1UIE/edit), as appropriate, while also keeping the EIC up-to-date.
 
 ## Process for inviting a new editor
 
 * Editorial board candidates most often start as guest editors.
-* After 3 months or their first review (which ever comes first) assess how the
+* After 3 months or their first review (which ever comes first), the peer review lead working with the EiC will assess how the
 review process went. Allow other editors to provide input as well.
 * Once it is determined that the guest editor is committed to support the pyOpenSci
 review process, you can email them to fully participate on the editorial board
@@ -142,7 +199,7 @@ using the template below.
 ```
 Hi [NAME HERE]:
 
-We would like to invite you to join the pyOpenSci editorial board as a full
+We would like to formally invite you to join the pyOpenSci editorial board as a full
 member. [*SPECIFIC REASONS FOR INVITATION (mention contributions TO pyOpenSci)*].
 We think you will make a wonderful addition to our pyOpenSci open review team!
 
@@ -180,81 +237,62 @@ Best,
 
 To onboard a new editor:
 
-* Ask them to add themselves to the [pyOpenSci website](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) using a pull request. If they are already listed on our website, then they only need to add
-the `title:` yaml element and update `contributor_type:` as see below:
+* Message the pyOpenSci Community Manager and the new editor in Slack, introducing them to one another. The Community Manager will collaborate with the new editor to create a blog post introducing them, which will in turn get posted on the pyOpenSci blog, promoted on social media, and included in an upcoming newsletter.
 
-```yaml
-- name: FirstName LastName
-  sort: 2
-  title: "Editor" # Make sure this says Editor
-  bio: ''
-  organization: ""
-  github_username: ghusernamehere
-  github_image_id: 11934090 # You can find this value by opening your github profile image
-  # in a new browser tab and grabbing the id https://avatars.githubusercontent.com/u/7649194?v=4 <-
-  # in this example 7649194 is the image_id
-  contributor_type:
-    - current editor # Make sure current editor is added here
-    - contributor
-  packages-submitted: [""]
-  packages-reviewed: ["pystiche"]
-  packages-editor: [""]
-```
-
-
-* Next, message the pyOpenSci Community Manager and the new editor in Slack, introducing them to one another. The Community Manager will collaborate with the new editor to create a blog post introducing them, which will in turn get posted on the pyOpenSci blog, promoted on social media, and included in an upcoming newsletter.
-
-* If they haven't already done, ask the new editor to turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
+* Ask the new editor to turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa) if they haven't already done so.
 
 * Give editors permissions they will need on GitHub to manage reviews:
   * For ad-hoc guest editors: invite the editor to the `software-submission` repository
     with "maintain" permissions.
-  * For new editors (not ad-hoc): invite editors to the pyOpenSci GitHub organzation
+  * For new editors (not ad-hoc): invite editors to the pyOpenSci GitHub organization
     as a member of the [`editorial-board`](https://github.com/orgs/pyOpenSci/teams/editorial-board) team. This will give them appropriate permissions and allow them to get team-specific notifications.
 
-<!-- do we need this?
-* Editors need access to the AirTable database of software review. 
-* * In the Slack workspace they need to be added to the editors team so that `@editors` will ping them too.
- -->
-* Add the new editor to the pyOpenSci Slack workspace and specifically the private editors channel.
+* Add the new editor to the pyOpenSci Slack workspace and specifically the `private-editorial` channel.
 
 * Post a welcome message for the new editor in the editor channel, pinging all editors.
+* Update the [website contributors.yml](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) file with the name of the new editor.
 
-<!--
-This is what ROS does... i need to think this through. it doesn't make sense
-to add names in so many places manually... maybe there is a better way
-* We add editors' names to
-    * [dev_guide authors list](https://github.com/ropensci/dev_guide/blob/main/index.Rmd)
-    * [dev_guide chapter introducing software review](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) (at two locations in this file, as editors and a bit below to remove them from the reviewers list)
-    * [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) (in two places in this file as well)
-Both the dev_guide and software-review README are automatically knit via continuous integration. -->
+:::{note}
+We have a bi-weekly cron job that parses through existing issues and grabs the names of editors, reviewers and authors. However, if you want the editors name to be listed on the website prior to a review beginning and/or sooner than the cron job might pick up their name, then we suggest that you add their name, and GitHub username and title to the contributors.yml file through a pull request.
 
-<!-- * Add editors to https://github.com/orgs/ropensci/teams/editors/members -->
+You do not need to fill out all of the elements of the YAML file - only the name, github user field and the `editorial_board: true` key:value pair.
 
-## Offboarding an editor
-
-When it's time for an editor to step down:
-
-* Thank them for their work!
-
-* Remove them from the editors-only channel and the editors Slack team.
-
-* Moved them to alumni-editor on the [pyOpenSci website](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) as follows:
+:::
 
 ```yaml
 - name: FirstName LastName
-  sort: 2
-  title: "Emeritus Editor" # Modify this to say Emeritus Editor
-  bio: ''
-  organization: ""
-  github_username: ghusernamehere
-  github_image_id: 11934090 # You can find this value by opening your github profile image
-  # in a new browser tab and grabbing the id https://avatars.githubusercontent.com/u/7649194?v=4 <-
-  # in this example 7649194 is the image_id
+  github_username: ghuser
+  github_image_id: 1234566
+  title:
+    - Editor # Title to be listed under their name
+  # ..... #
+  editorial_board: true # Be sure editorial_board is set to true
+  emeritus_editor: false # Emeritus is initially set to false
+  # ..... #
   contributor_type:
-    - current editor # Make sure emeritus editor is here
-    - contributor
-  packages-submitted: [""]
-  packages-reviewed: ["pystiche"]
-  packages-editor: [""]
+    - editor # This field will be automatically updated after their first review
+    - guidebook-contrib
+    - reviewer
+```
+
+## Off-boarding an editor
+
+When it is time for an editor to step down, do the following:
+
+* Thank them for their work!
+* Remove them from the editors-only Slack channel and the editors GitHub team.
+* Move them to emeritus-editor on the [pyOpenSci website](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) as follows:
+
+```yaml
+- name: FirstName LastName
+  github_username: ghuser
+  github_image_id: 1234566
+  # ..... more here ... #
+  editorial_board: false # Be sure editorial_board is set to FALSE
+  emeritus_editor: true # Emeritus is now true if they've served as an editor
+  # .. #
+  contributor_type:
+    - editor # This field will be automatically updated after their first review
+    - guidebook-contrib
+    - reviewer
 ```

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -30,7 +30,7 @@ from different backgrounds, cultures, genders, and domains.
 A new editor will be considered a guest editor for the first 3 months of their
 tenure and/or until they have completed their first review. Once they have
 completed a review, they can be considered a full editor as deemed appropriate
-by the software review lead and the current editorial board.
+by the Software Review Lead and the current editorial board.
 
 #### _ad hoc_ Guest Editors
 
@@ -76,7 +76,7 @@ pyOpenSci.
 
 ## Where to Find New Editors
 
-Typically the Editor in Chief will work with the Peer Review Lead to find and
+Typically the Editor in Chief will work with the Software Review Lead to find and
 onboard new editors in scientific topical areas where pyOpenSci has existing
 gaps.
 
@@ -102,7 +102,7 @@ allow you to cast an even wider net to find new interested editors.
 
 :::{todo}
 Ideally, we want to have an online interface for the editors / EiC to own the
-process. When we have a link that will allow the EiC / peer review lead to
+process. When we have a link that will allow the EiC / Software Review Lead to
 search through something online, we should add it --
 
 pyOpenSci maintains a database of contributors, and the Community Manager can
@@ -155,7 +155,7 @@ an individual Direct Message (DM) because:
 * It allows other community members who may know of potential editors to see the request and potentially respond.
 :::
 
-Our Community Manager interacts with the broader community and partner communities and as such often interacts with people who may be interested in joining our pyOpenSci review team. The Community Manager may from time to time meet community members who might make great editors or reviewers. In those cases they will share that information with the current Editor in Chief and Peer Review Lead.
+Our Community Manager interacts with the broader community and partner communities and as such often interacts with people who may be interested in joining our pyOpenSci review team. The Community Manager may from time to time meet community members who might make great editors or reviewers. In those cases they will share that information with the current Editor in Chief and Software Review Lead.
 
 :::{todo}
 pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
@@ -175,7 +175,7 @@ It is important that a new reviewer or a new editor fill out the appropriate for
 
 ## On-boarding a new editor
 
-The Editor in Chief, working closely with the Peer Review Lead, is responsible for inviting and onboarding a new editor to our peer review process.
+The Editor in Chief, working closely with the Software Review Lead, is responsible for inviting and onboarding a new editor to our peer review process.
 
 When the EIC has identified an editor who is not currently part of the pyOpenSci community, they should:
 
@@ -190,7 +190,7 @@ The Community Manager will ensure that any new member that joins our Slack works
 ## Process for inviting a new editor
 
 * Editorial board candidates most often start as guest editors.
-* After 3 months or their first review (which ever comes first), the Peer Review Lead working with the EiC will assess how the
+* After 3 months or their first review (which ever comes first), the Software Review Lead working with the EiC will assess how the
 review process went. Allow other editors to provide input as well.
 * Once it is determined that the guest editor is committed to support the pyOpenSci
 review process, you can email them to fully participate on the editorial board

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -28,10 +28,15 @@ Chief. In the future we hope to find someone with interest in leading peer revie
 
 The pyOpenSci community continues to grow rapidly, and as such we now have a much stronger reach on social media than ever before. While you will collaborate closely with the pyOpenSci Community Manager to recruit editors through social media campaigns, also consider the following sources:
 
+The pyOpenSci community continues to grow rapidly, and as such we now have a much stronger reach on social media than ever before. While you will collaborate closely with the pyOpenSci Community Manager to recruit editors through social media campaigns, also consider the following sources:
+
 * Contributors who have reviewed for pyOpenSci
 * Contributors who have submitted a package to pyOpenSci
 * Contributors who have served as a guest editor
 * Colleagues that you know who have reviewed for JOSS or rOpenSci who have Python expertise
+
+pyOpenSci maintains a database of contributors, and the Community Manager can assist you in identifying individuals who may be a good fit. Please reach out to them either in a private Slack message or via email, at [media@pyopensci.org](mailto:media@pyopensci.org). 
+
 
 pyOpenSci maintains a database of contributors, and the Community Manager can assist you in identifying individuals who may be a good fit. Please reach out to them either in a private Slack message or via email, at [media@pyopensci.org](mailto:media@pyopensci.org). 
 
@@ -42,7 +47,27 @@ In an ideal world, you’d be able to start your search well in advance of when 
 
 ### The Editorial Team
 It’s helpful to first check with the existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board), in order to see if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private Slack channel as follows:
+In an ideal world, you’d be able to start your search well in advance of when you think you may need to expand the editorial team. However, due to the influx of new packages, this isn’t always possible. As such, when you begin your search, start with the existing editorial team as well as the pyOpenSci Community Manager.
 
+### The Editorial Team
+It’s helpful to first check with the existing [Editorial Team](https://www.pyopensci.org/about-peer-review/index.html#meet-our-editorial-board), in order to see if anyone can identify reviewers who excelled and may be a good editorial candidate. Do this in a private Slack channel as follows:
+
+* Start a private channel for discussion. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
+* Ping editors using @here to be sure they get a notification, as this is an important topic.
+* Wait for a majority of editors to chime in before inviting someone. Provide editors one week to respond on Slack.
+
+### The pyOpenSci Community Manager
+The Community Manager is available to assist with editor recruitment at any stage in the process, even if it’s before you think you might need editors. Standard recruitment involves targeted social media posts [(similar to this)](https://fosstodon.org/@pyOpenSci/112497485980274296), a blog post, and call-outs in both our monthly and weekly newsletters. To kick off this process, or to request additional ideas for recruitment, reach out to the Community Manager via private message in Slack to let them know:
+
+* That you’re looking for editors!
+* Which type(s) of editors you’re looking for (full, guest).
+* Any specific domains or technical skills you need an editor to have, or if it’s a general call for editors.
+* Any specific packages that need an editor.
+* Any additional promotion you’d like, beyond social media posts, a blog post, and newsletter updates.
+
+```{note}
+pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
+```
 * Start a private channel for discussion. This ensures there is not a visible history in a public channel that a new editor may see in the future (this could be awkward for someone to see!)
 * Ping editors using @here to be sure they get a notification, as this is an important topic.
 * Wait for a majority of editors to chime in before inviting someone. Provide editors one week to respond on Slack.
@@ -66,7 +91,9 @@ We prefer that editors have some experience with reviewing software. This experi
 could come from a previous review they worked on with pyOpenSci, rOpenSci or JOSS.
 
 If they do not have experience, as may be the case when we receive a large number of package submissions while also establishing a robust editorial board, we do offer a "mentorship" process. Editor mentorship is where someone with existing editorial experience mentors the new editor through their first review(s).
+If they do not have experience, as may be the case when we receive a large number of package submissions while also establishing a robust editorial board, we do offer a "mentorship" process. Editor mentorship is where someone with existing editorial experience mentors the new editor through their first review(s).
 
+A new editor will be considered a guest editor for the first 3 months of their tenure
 A new editor will be considered a guest editor for the first 3 months of their tenure
 and/or until they have completed their first review. Once they have a completed
 a review they can be considered to be a full editor as deemed appropriate by the
@@ -84,6 +111,24 @@ In this case, you may consider using our internal reviewer signup list to see if
 
 ## Process for inviting a first-time community member
 
+### Through the EIC
+
+The Editor in Chief is ultimately the individual responsible for inviting a first-time editor, and when the EIC has identified an editor who is not currently part of the pyOpenSci community, they should:
+
+* Extend a Slack invitation to the individual
+* Welcome the individual in Slack, and provide them with access to the #private-editorial-team and any other channels as needed. 
+
+Both the Community Manager and the Executive Director receive a notification whenever someone joins the Slack group, and the Community Manager will ensure that the new member is welcomed and set up with anything they need for Slack. 
+
+### Through the Community Manager
+
+Although the EIC is responsible for inviting identified editors to the Slack group, it’s common for the Community Manager to interact with prospective community members that may make good reviewers or editors in the future. As such, at the Community Manager’s discretion they may invite members to Slack, and share the member’s background with the EIC, letting them know if the new community member may make a good reviewer or editor.
+
+In addition, the Community Manager will have the new member fill out the [reviewer form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform) or the [editor form](https://docs.google.com/forms/d/17NW0P_h8gpmzf7Fr0cAd8aEbIUWPljPfg4d7Rjs1UIE/edit), as appropriate.
+
+### Through the Executive Director
+
+The Executive Director may invite community members to the Slack group at their discretion, and similar to the Community Manager, may have the member completed the [reviewer form](https://docs.google.com/forms/d/e/1FAIpQLSeVf-L_1-jYeO84OvEE8UemEoCmIiD5ddP_aO8S90vb7srADQ/viewform) or the [editor form](https://docs.google.com/forms/d/17NW0P_h8gpmzf7Fr0cAd8aEbIUWPljPfg4d7Rjs1UIE/edit), as appropriate, while also keeping the EIC up-to-date.
 
 ## Process for inviting a new editor
 
@@ -157,7 +202,7 @@ the `title:` yaml element and update `contributor_type:` as see below:
 ```
 
 
-* Next work with the new editor to create a blog post introducing them which will get [posted on the pyOpenSci blog](https://www.pyopensci.org/blog).
+* Next, message the pyOpenSci Community Manager and the new editor in Slack, introducing them to one another. The Community Manager will collaborate with the new editor to create a blog post introducing them, which will in turn get posted on the pyOpenSci blog, promoted on social media, and included in an upcoming newsletter.
 
 * If they haven't already done, ask the new editor to turn on [two-factor authentication (2FA) for GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
 
@@ -168,7 +213,7 @@ the `title:` yaml element and update `contributor_type:` as see below:
     as a member of the [`editorial-board`](https://github.com/orgs/pyOpenSci/teams/editorial-board) team. This will give them appropriate permissions and allow them to get team-specific notifications.
 
 <!-- do we need this?
-* Editors need access to the AirTable database of software review.
+* Editors need access to the AirTable database of software review. 
 * * In the Slack workspace they need to be added to the editors team so that `@editors` will ping them too.
  -->
 * Add the new editor to the pyOpenSci Slack workspace and specifically the private editors channel.

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -32,10 +32,10 @@ tenure and/or until they have completed their first review. Once they have
 completed a review, they can be considered a full editor as deemed appropriate
 by the software review lead and the current editorial board.
 
-#### Adhoc Guest Editors
+#### _ad hoc_ Guest Editors
 
 Adhoc editors are editors with specific skill sets that are brought in to lead
-a single review. Examples of when there might be a need for an ad-hoc editor
+a single review. Examples of when there might be a need for an _ad hoc_ editor
 include:
 
 * If there is a conflict of interest between a package submitter and the
@@ -95,7 +95,7 @@ You might find good candidates to be an editor through:
   `#software-review` channel)
 
 When all of the above fails to return a good new editor candidate, you can find
-support from our pyOpenSci community manager who will post an open call on our
+support from our pyOpenSci Community Manager who will post an open call on our
 [social media channels](https://www.pyopensci.org/handbook/community/social.html)
 with a link to our editorial board sign-up form. Using our online network will
 allow you to cast an even wider net to find new interested editors.
@@ -151,11 +151,11 @@ To get support from the Community Manager in recruiting editors (or reviewers) f
 It's helpful to post in our `#software-review` channel rather than
 an individual Direct Message (DM) because:
 
-* It allows other editors to see the type of expertise that you are requesting and that we offer this support from our community manager.
+* It allows other editors to see the type of expertise that you are requesting and that we offer this support from our Community Manager.
 * It allows other community members who may know of potential editors to see the request and potentially respond.
 :::
 
-Our Community Manager interacts with the broader community and partner communities and as such often interacts with people who may be interested in joining our pyOpenSci review team. The community manager may from time to time meet community members who might make great editors or reviewers. In those cases they will share that information with the current EiC and peer review lead.
+Our Community Manager interacts with the broader community and partner communities and as such often interacts with people who may be interested in joining our pyOpenSci review team. The Community Manager may from time to time meet community members who might make great editors or reviewers. In those cases they will share that information with the current Editor in Chief and Peer Review Lead.
 
 :::{todo}
 pyOpenSci anticipates being able to send targeted emails to community members that meet certain criteria related to domain expertise by the Fall of 2024. Please reach out to the pyOpenSci Community Manager with any questions about this process!
@@ -190,7 +190,7 @@ The Community Manager will ensure that any new member that joins our Slack works
 ## Process for inviting a new editor
 
 * Editorial board candidates most often start as guest editors.
-* After 3 months or their first review (which ever comes first), the peer review lead working with the EiC will assess how the
+* After 3 months or their first review (which ever comes first), the Peer Review Lead working with the EiC will assess how the
 review process went. Allow other editors to provide input as well.
 * Once it is determined that the guest editor is committed to support the pyOpenSci
 review process, you can email them to fully participate on the editorial board
@@ -255,7 +255,7 @@ To onboard a new editor:
 :::{note}
 We have a bi-weekly cron job that parses through existing issues and grabs the names of editors, reviewers and authors. However, if you want the editors name to be listed on the website prior to a review beginning and/or sooner than the cron job might pick up their name, then we suggest that you add their name, and GitHub username and title to the contributors.yml file through a pull request.
 
-You do not need to fill out all of the elements of the YAML file - only the name, github user field and the `editorial_board: true` key:value pair.
+You do not need to fill out all of the elements of the YAML file - only the name, GitHub user field and the `editorial_board: true` key:value pair.
 
 :::
 


### PR DESCRIPTION
i added commits on top of #290 but something is super funky with those commits! it should be ok however once we merge. 

what is actually missing from this page now is reviewer onboarding!! so i'll open this in draft. 