### PR TITLE
Switch url to pyopensci from tinyurl

### DIFF
--- a/about/intro.md
+++ b/about/intro.md
@@ -121,7 +121,7 @@ You can identify pyOpenSci packages that have been peer-reviewed by the green
 :::{figure-md} pyos-badge
 :class: myclass
 
-<img src="https://pyopensci.org/images/badges/peer-reviewed.svg" alt="The pyOpenSci Peer Reviewed badge" class="bg-primary mb-1" width="200px">
+<img src="https://pyopensci.org/badges/peer-reviewed.svg" alt="The pyOpenSci Peer Reviewed badge" class="bg-primary mb-1" width="200px">
 
 pyOpenSci Peer Review Badge
 :::

--- a/about/intro.md
+++ b/about/intro.md
@@ -121,7 +121,7 @@ You can identify pyOpenSci packages that have been peer-reviewed by the green
 :::{figure-md} pyos-badge
 :class: myclass
 
-<img src="https://tinyurl.com/y22nb8up" alt="The pyOpenSci badge" class="bg-primary mb-1" width="200px">
+<img src="https://pyopensci.org/images/badges/peer-reviewed.svg" alt="The pyOpenSci Peer Reviewed badge" class="bg-primary mb-1" width="200px">
 
 pyOpenSci Peer Review Badge
 :::

--- a/appendices/package-approval-template.md
+++ b/appendices/package-approval-template.md
@@ -9,7 +9,7 @@ There are a few things left to do to wrap up this submission:
 
 - [ ] Activate [Zenodo](https://zenodo.org/) watching the repo if you haven't already done so.
 - [ ] Tag and create a release to create a Zenodo version and DOI.
-- [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci Peer-Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number)`.
+- [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci Peer-Reviewed](https://pyopensci.org/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number)`.
 - [ ] Please fill out the [post-review survey](https://forms.gle/BLGVCfUdiJHS5YJY7). All maintainers and reviewers should fill this out.
 
 <IF JOSS SUBMISSION>

--- a/appendices/package-approval-template.md
+++ b/appendices/package-approval-template.md
@@ -9,7 +9,7 @@ There are a few things left to do to wrap up this submission:
 
 - [ ] Activate [Zenodo](https://zenodo.org/) watching the repo if you haven't already done so.
 - [ ] Tag and create a release to create a Zenodo version and DOI.
-- [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/issue-number)`.
+- [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci Peer-Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number)`.
 - [ ] Please fill out the [post-review survey](https://forms.gle/BLGVCfUdiJHS5YJY7). All maintainers and reviewers should fill this out.
 
 <IF JOSS SUBMISSION>

--- a/how-to/author-guide.md
+++ b/how-to/author-guide.md
@@ -250,7 +250,7 @@ Once your package is approved, a few things will happen:
 1. We will ask you to ensure that your package is being tracked / archived using
    Zenodo. You will then want to created a tagged release representing the version of the
    package accepted by pyOpenSci.
-1. We will ask you to add the pyOpenSci badge [![pyOpenSci Peer Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number) to the
+1. We will ask you to add the pyOpenSci badge [![pyOpenSci Peer Reviewed](https://pyopensci.org/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number) to the
    top of your **README.md** file.
 1. We will promote your package on our social media channels!
 1. We will invite you to write a blog on our website spotlighting your package. The blogs that our maintainers write are some of the most popular content on the website!

--- a/how-to/author-guide.md
+++ b/how-to/author-guide.md
@@ -250,7 +250,7 @@ Once your package is approved, a few things will happen:
 1. We will ask you to ensure that your package is being tracked / archived using
    Zenodo. You will then want to created a tagged release representing the version of the
    package accepted by pyOpenSci.
-1. We will ask you to add the pyOpenSci badge [![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/issue-number) to the
+1. We will ask you to add the pyOpenSci badge [![pyOpenSci Peer Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](https://github.com/pyOpenSci/software-review/issues/issue-number) to the
    top of your **README.md** file.
 1. We will promote your package on our social media channels!
 1. We will invite you to write a blog on our website spotlighting your package. The blogs that our maintainers write are some of the most popular content on the website!

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -407,7 +407,7 @@ interested in this option, consider doing the following:
     -   Go to the repository settings in the "pyOpenSci" GitHub organization and give the author "Admin" access to the repository.
 -   Ask the author to:
     -  Change any needed links, such as those for CI badges.
-    -  Add pyOpenSci badge: `[![pyOpenSci Peer Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](link-to-issue)`.
+    -  Add pyOpenSci badge: `[![pyOpenSci Peer Reviewed](https://pyopensci.org/badges/peer-reviewed.svg)](link-to-issue)`.
     -   Re-activate CI services:
         -  For Travis, activating the project in the pyOpenSci account should be sufficient.
         -  For AppVeyor, tell the author to update the GitHub link in their badge, but do not transfer the project: AppVeyor projects should remain under the authors' account. The badge is `[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/pyOpenSci/pkgname?branch=main&svg=true)](https://ci.appveyor.com/project/individualaccount/pkgname)`.

--- a/how-to/editors-guide.md
+++ b/how-to/editors-guide.md
@@ -407,7 +407,7 @@ interested in this option, consider doing the following:
     -   Go to the repository settings in the "pyOpenSci" GitHub organization and give the author "Admin" access to the repository.
 -   Ask the author to:
     -  Change any needed links, such as those for CI badges.
-    -  Add pyOpenSci badge: `[![pyOpenSci](https://tinyurl.com/y22nb8up)](link-to-issue)`.
+    -  Add pyOpenSci badge: `[![pyOpenSci Peer Reviewed](https://pyopensci.org/images/badges/peer-reviewed.svg)](link-to-issue)`.
     -   Re-activate CI services:
         -  For Travis, activating the project in the pyOpenSci account should be sufficient.
         -  For AppVeyor, tell the author to update the GitHub link in their badge, but do not transfer the project: AppVeyor projects should remain under the authors' account. The badge is `[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/pyOpenSci/pkgname?branch=main&svg=true)](https://ci.appveyor.com/project/individualaccount/pkgname)`.

--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ programmers and researchers.
 :::{figure-md} pyos-badge-home
 :class: myclass
 
-<img src="https://pyopensci.org/images/badges/peer-reviewed.svg" alt="The pyOpenSci badge- On the left is the badge in grey and it says pyOpenSci. On the right it is bright green and says Peer Reviewed." class="bg-primary mb-1" width="200px">
+<img src="https://pyopensci.org/badges/peer-reviewed.svg" alt="The pyOpenSci badge- On the left is the badge in grey and it says pyOpenSci. On the right it is bright green and says Peer Reviewed." class="bg-primary mb-1" width="200px">
 
 **pyOpenSci Peer Review Badge will appear on the README.md file of packages that have been
 reviewed and vetted by us.**

--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ programmers and researchers.
 :::{figure-md} pyos-badge-home
 :class: myclass
 
-<img src="https://tinyurl.com/y22nb8up" alt="The pyOpenSci badge- On the left is the badge in grey and it says pyOpenSci. On the right it is bright green and says Peer Reviewed." class="bg-primary mb-1" width="200px">
+<img src="https://pyopensci.org/images/badges/peer-reviewed.svg" alt="The pyOpenSci badge- On the left is the badge in grey and it says pyOpenSci. On the right it is bright green and says Peer Reviewed." class="bg-primary mb-1" width="200px">
 
 **pyOpenSci Peer Review Badge will appear on the README.md file of packages that have been
 reviewed and vetted by us.**


### PR DESCRIPTION
Implements: https://github.com/pyOpenSci/software-peer-review/issues/293
Depends on: https://github.com/pyOpenSci/pyopensci.github.io/pull/428

Pretty simple! Basically I think link shorteners are bad, there's no reason to effectively embed a tracking pixel in every reviewed repo, and in this case it would be nice to give a nice canonical location to these badges that is sure to exist for as long as we do as an organization :).