### PR TITLE
docs: adjust language for peer review mentorship

### DIFF
--- a/about/package-scope.md
+++ b/about/package-scope.md
@@ -218,9 +218,7 @@ Packages to aid with instruction.
 
 ### Astropy
 
-We have a [community affiliated package partnership with Astropy](../partners/astropy). Check out [packages that are under review and will
-be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue%20is%3Aopen%20label%3Aastropy).
-
+We have a [community affiliated package partnership with Astropy](../partners/astropy). To see packages currently under review for Astropy affiliation, visit the [open issues page](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue+is%3Aopen) and select the `astropy` label.
 ### Pangeo
 
 We have a [partnership with Pangeo](../partners/pangeo). Often times packages submitted as a part of that partnership are also in the geospatial domain.

--- a/about/package-scope.md
+++ b/about/package-scope.md
@@ -219,7 +219,7 @@ Packages to aid with instruction.
 ### Astropy
 
 We have a [community affiliated package partnership with Astropy](../partners/astropy). Check out [packages that are under review and will
-be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue%20state%3Aopen%20label%3Aastropy).
+be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue%20is%3Aopen%20label%3Aastropy).
 
 ### Pangeo
 

--- a/about/package-scope.md
+++ b/about/package-scope.md
@@ -219,8 +219,7 @@ Packages to aid with instruction.
 ### Astropy
 
 We have a [community affiliated package partnership with Astropy](../partners/astropy). Check out [packages that are under review and will
-be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aopen+is%3Aissue+label%3Aastropy).
-
+be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aopen%20is%3Aissue%20label%3Aastropy).
 
 ### Pangeo
 

--- a/about/package-scope.md
+++ b/about/package-scope.md
@@ -219,7 +219,7 @@ Packages to aid with instruction.
 ### Astropy
 
 We have a [community affiliated package partnership with Astropy](../partners/astropy). Check out [packages that are under review and will
-be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aopen%20is%3Aissue%20label%3Aastropy).
+be considered for Astropy affiliated status here](https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue%20state%3Aopen%20label%3Aastropy).
 
 ### Pangeo
 

--- a/how-to/finding-reviewers.md
+++ b/how-to/finding-reviewers.md
@@ -84,12 +84,8 @@ for usability.
 If a new reviewer is interested in becoming a reviewer but would like some
 support, do the following:
 
-1. Reach out to the **Editor in Chief** & **Peer Review Lead** to let them
-   know that you have a reviewer that would like to work with a mentor.
-2. They will then post in the `#software-review` channel to see if anyone is
-   available to provide support to the new reviewer.
-3. If you don't get any responses from the post above, reach out to our
-   Community Manager who will try to find someone to fill the mentorship role!
+1. The Editor can lead the effort to find mentors for the new reviewers by posting in the `#software-review` Slack channel for help. 
+2. If the Editor needs support in finding a mentor, they can contact the **EiC** or **peer review lead** for guidance.
 
 ### Once a Mentor is Identified
 

--- a/how-to/finding-reviewers.md
+++ b/how-to/finding-reviewers.md
@@ -84,7 +84,7 @@ for usability.
 If a new reviewer is interested in becoming a reviewer but would like some
 support, do the following:
 
-1. The Editor can lead the effort to find mentors for the new reviewers by posting in the `#software-review` Slack channel for help. 
+1. The Editor can lead the effort to find mentors for the new reviewers by posting in the `#software-review` Slack channel for help.
 2. If the Editor needs support in finding a mentor, they can contact the **EiC** or **peer review lead** for guidance.
 
 ### Once a Mentor is Identified


### PR DESCRIPTION
**Fixes**
- Adjusts the language to reflect the editor's steps while finding a mentor for a new reviewer.
- Remove `label` from the URL, and adjust wording to fix htmlproofer error.

resolves #313 