### PR TITLE
enh: add .github repo with defaults to eic checks

### DIFF
--- a/appendices/editor-in-chief-checks.md
+++ b/appendices/editor-in-chief-checks.md
@@ -9,15 +9,15 @@ to work on them before the review process begins.
 Please check our [Python packaging guide](https://www.pyopensci.org/python-package-guide) for more information on the elements
 below.
 
-- [ ] **Installation** The package can be installed from a community repository such as PyPI (preferred), and/or a community channel on conda (e.g. conda-forge, bioconda).
+- [ ] **Installation** The package can be installed from a community repository such as PyPI (preferred), and/or a community channel on conda (e.g., conda-forge, bioconda).
   - [ ] The package imports properly into a standard Python environment `import package`.
 - [ ] **Fit** The package meets criteria for [fit](https://www.pyopensci.org/software-peer-review/about/package-scope.html#what-types-of-packages-does-pyopensci-review) and [overlap](https://www.pyopensci.org/software-peer-review/about/package-scope.html#package-overlap).
-- [ ] **Documentation** The package has sufficient online documentation to allow us to evaluate package function and scope *without installing the package*. This includes:
+- [ ] **Documentation** The package has sufficient online documentation to allow us to evaluate the package's function and scope *without installing the package*. This includes:
   - [ ] User-facing documentation that overviews how to install and start using the package.
-  - [ ] Short tutorials that help a user understand how to use the package and what it can do for them.
-  - [ ] API documentation (documentation for your code's functions, classes, methods and attributes): this includes clearly written docstrings with variables defined using a standard docstring format.
+  - [ ] Short quickstart tutorials that help a user understand how to use the package and what it can do for them.
+  - [ ] API documentation (documentation for your code's functions, classes, methods, and attributes): this includes clearly written docstrings with variables defined using a standard docstring format.
 - [ ] Core GitHub repository Files
-  - [ ] **README** The package has a `README.md` file with clear explanation of what the package does, instructions on how to install it, and a link to development instructions.
+  - [ ] **README** The package has a `README.md` file with a clear explanation of what the package does, instructions on how to install it, and a link to development instructions.
   - [ ] **Contributing File** The package has a `CONTRIBUTING.md` file that details how to install and contribute to the package.
   - [ ] **Code of Conduct** The package has a `CODE_OF_CONDUCT.md` file.
   - [ ] **License** The package has an [OSI approved license](https://opensource.org/licenses).
@@ -29,10 +29,12 @@ NOTE: We prefer that you have development instructions in your documentation too
 - [ ] **Archive** (JOSS only, may be post-review): The repository DOI resolves correctly.
 - [ ] **Version** (JOSS only, may be post-review): Does the release version given match the GitHub release (v1.0.0)?
 
+**Optional:** Let projects know that it's a great idea for projects to have a .github repository for the project organization where they can host a commonly used LICENSE, Code of Conduct, and even a YAML file with label definitions. These items will then be automatically applied to every repository in the organization to ensure consistency (but can be customized within repos too). The [SunPy project](https://github.com/sunpy/.github/) has a great example of this.
+
 ---
 - [ ] [Initial onboarding survey was filled out ](https://forms.gle/F9mou7S3jhe8DMJ16)
 We appreciate each maintainer of the package filling out this survey individually. :raised_hands:
-Thank you authors in advance for setting aside five to ten minutes to do this. It truly helps our organization. :raised_hands:
+Thank you, authors, in advance for setting aside five to ten minutes to do this. It truly helps our organization. :raised_hands:
 ---
 
 *******

--- a/appendices/review-template.md
+++ b/appendices/review-template.md
@@ -13,7 +13,7 @@ The package includes all the following forms of documentation:
 
 - [ ] **A statement of need** clearly stating problems the software is designed to solve and its target audience in the README file.
 - [ ] **Installation instructions:** for the development version of the package and any non-standard dependencies in README.
-- [ ] **Short quickstart tutorials** demonstrating significant functionality that runs successfully locally.
+- [ ] **Short quickstart tutorials** demonstrating significant functionality that successfully runs locally.
 - [ ] **Function Documentation:** for all user-facing functions.
 - [ ] **Examples** for all user-facing functions.
 - [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING.

--- a/appendices/review-template.md
+++ b/appendices/review-template.md
@@ -5,19 +5,19 @@
 
 *Please check off boxes as applicable, and elaborate in comments below. Your review is not limited to these topics, as described in the reviewer guide*
 
-- [ ] As the reviewer I confirm that there are no conflicts of interest for me to review this work (If you are unsure whether you are in conflict, please speak to your editor _before_ starting your review).
+- [ ] As the reviewer, I confirm that there are no conflicts of interest for me to review this work (If you are unsure whether you are in conflict, please speak to your editor _before_ starting your review).
 
 #### Documentation
 
 The package includes all the following forms of documentation:
 
-- [ ] **A statement of need** clearly stating problems the software is designed to solve and its target audience in README.
+- [ ] **A statement of need** clearly stating problems the software is designed to solve and its target audience in the README file.
 - [ ] **Installation instructions:** for the development version of the package and any non-standard dependencies in README.
-- [ ] **Vignette(s)** demonstrating major functionality that runs successfully locally.
+- [ ] **Short quickstart tutorials** demonstrating significant functionality that runs successfully locally.
 - [ ] **Function Documentation:** for all user-facing functions.
 - [ ] **Examples** for all user-facing functions.
 - [ ] **Community guidelines** including contribution guidelines in the README or CONTRIBUTING.
-- [ ] **Metadata** including author(s), author e-mail(s), a url, and any other relevant metadata e.g., in a `pyproject.toml` file or elsewhere.
+- [ ] **Metadata** including author(s), author e-mail(s), a URL, and any other relevant metadata, for example, in a `pyproject.toml` file or elsewhere.
 
 Readme file  requirements
 The package meets the readme requirements below:
@@ -30,11 +30,10 @@ The README should include, from top to bottom:
 - [ ] Badges for:
     - [ ] Continuous integration and test coverage,
     - [ ] Docs building (if you have a documentation website),
-    - [ ] A [repostatus.org](https://www.repostatus.org/) badge,
     - [ ] Python versions supported,
     - [ ] Current package version (on PyPI / Conda).
 
-*NOTE: If the README has many more badges, you might want to consider using a table for badges: [see this example](https://github.com/ropensci/drake). Such a table should be more wide than high. (Note that the a badge for pyOpenSci peer-review will be provided upon acceptance.)*
+*NOTE: If the README has many more badges, you might want to consider using a table for badges: [see this example](https://github.com/ropensci/drake). Such a table should be wider than high. A badge for pyOpenSci peer review will be provided when the package is accepted.*
 
 - [ ] Short description of package goals.
 - [ ] Package installation instructions
@@ -46,8 +45,9 @@ The README should include, from top to bottom:
 - [ ] Citation information
 
 #### Usability
+
 Reviewers are encouraged to submit suggestions (or pull requests) that will improve the usability of the package as a whole.
-Package structure should follow general community best-practices. In general please consider whether:
+The package structure should follow the general community best practices. In general, please consider whether:
 
 - [ ] Package documentation is clear and easy to find and use.
 - [ ] The need for the package is clear

--- a/how-to/editor-in-chief-guide.md
+++ b/how-to/editor-in-chief-guide.md
@@ -102,18 +102,18 @@ When a new package is submitted for review, the Editor in Chief should:
 
 ### 1. ✔️ Tag the issue with the `0/pre-review-checks` label in GitHub
 
-### 2. ✔️ Add a partner tag if the author selected a partner affiliation
+### 2. ✔️ Add a partner label to the issue if the author selected a partner affiliation
 
 pyOpenSci supports
 [partnerships with other communities](partner-communities). Astropy is our only active partner.
 
-If the author selects a partner in the submission template,
+If the author selects a partner in the software submission template,
 
-1. Notify an editor from that community that a review may be forthcoming. — they will typically take
+1. Notify an editor from that community that a review may be forthcoming. They will typically take
 the lead on that review.
-2. Add the appropriate partner label to the issue.
+2. Add the **appropriate partner label** to the issue. Example `Astropy`.
 
-The partner section of the submission looks like this:
+The partner section of the software submission form looks like this:
 
 ```markdown
 ## Community Partnerships


### PR DESCRIPTION
closes #259 , #289 

This adds a note about how maintainers can add a .github repo to their org to maintain standard defaults for LICENSE, COC and more using SunPy as an example!