### PR TITLE
Update name of infrastructure slack channel

### DIFF
--- a/how-to/editor-in-chief-guide.md
+++ b/how-to/editor-in-chief-guide.md
@@ -278,7 +278,7 @@ this issue how your package is "best in class." You can refer to our
 
 During the review, you may encounter challenges that require resolution.
 
-* For **technical issues** such as repository access, GitHub integration, or platform problems, post in the `#pyos-infrastructure` Slack channel where our technical team can assist you.
+* For **technical issues** such as repository access, GitHub integration, or platform problems, post in the `#pyos-maintainers-infrastructure` Slack channel where our technical team can assist you.
 
 * For **behavior concerns** including unprofessional communication, harassment, or guideline violations, use our [pyOpenSci Code of Conduct](https://www.pyopensci.org/handbook/CODE_OF_CONDUCT.html) as guidance. Follow the Code of Conduct reporting procedures and notify the Peer Review Lead of the issue.
 

--- a/how-to/peer-review-lead.md
+++ b/how-to/peer-review-lead.md
@@ -40,7 +40,7 @@ Keep an eye on a few things when you check in:
 
 ### 1. Dashboard: check the date the comment date for every review
 
-Before you begin, ensure the peer review dashboard is up to date. At the top of the dashboard, you will see the **Last Updated** date. The metrics repository has a cron job that runs weekly to update review status metrics. If the date at the top of the page is older than 1-2 weeks, likely, a pull request, [similar to this one](https://github.com/pyOpenSci/metrics/pull/147) needs to be merged. Go ahead and merge that PR if one exists. If the dashboard date is old and there is no open PR to merge, our cron job has likely failed. In that case, please leave a note in our Slack `#pyos-infrastructure` channel. Our infrastructure lead can investigate and resolve any issues that arise with our build.
+Before you begin, ensure the peer review dashboard is up to date. At the top of the dashboard, you will see the **Last Updated** date. The metrics repository has a cron job that runs weekly to update review status metrics. If the date at the top of the page is older than 1-2 weeks, likely, a pull request, [similar to this one](https://github.com/pyOpenSci/metrics/pull/147) needs to be merged. Go ahead and merge that PR if one exists. If the dashboard date is old and there is no open PR to merge, our cron job has likely failed. In that case, please leave a note in our Slack `#pyos-maintainers-infrastructure` channel. Our infrastructure lead can investigate and resolve any issues that arise with our build.
 
 :::{image} /images/peer-review-metrics-dashboard.png
 :alt: Dashboard last updated date


### PR DESCRIPTION
Channel recently changed names from #pyos-infrastructure to #pyos-maintainers-infrastructure

```
grep -lR "#pyos-infrastructure" ./* | xargs sed -i -e 's/#pyos-infrastructure/#pyos-maintainers-infrastructure/g'
```