### PR TITLE
homepage: use `grid-item-card` instead of nesting `card`s and `grid-item`s

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,30 +31,25 @@ drive open science.
 :class-container: text-center
 :gutter: 3
 
-::::{grid-item}
-:::{card} {octicon}`book;1.5em;sd-mr-1` Learn About Software Peer Review
+::::{grid-item-card} {octicon}`book;1.5em;sd-mr-1` Learn About Software Peer Review
 :class-card: left-aligned
 :link: about/intro
 :link-type: doc
 
 Get a basic overview of our open peer review process for Python scientific open source
 software.
-:::
 ::::
 
-::::{grid-item}
-:::{card} {octicon}`rocket;1.5em;sd-mr-1` Package Scope (What We Review)
+::::{grid-item-card} {octicon}`rocket;1.5em;sd-mr-1` Package Scope (What We Review)
 :link: about/package-scope
 :link-type: doc
 :class-header: bg-light
 
 We review packages that support scientists creating open science workflows.
 Learn about the scope of the packages that we review.
-:::
 ::::
 
-::::{grid-item}
-:::{card} {octicon}`code-square;1.5em;sd-mr-1`Authors Guide
+::::{grid-item-card} {octicon}`code-square;1.5em;sd-mr-1` Authors Guide
 :link: how-to/author-guide
 :link-type: doc
 :class-header: bg-light
@@ -62,21 +57,17 @@ Learn about the scope of the packages that we review.
 Are you a package author / maintainer? ✨
 
 Learn how to submit a package for peer review with pyOpenSci.
-:::
 ::::
 
-::::{grid-item}
-:::{card} {octicon}`pencil;1.5em;sd-mr-1`Editors Guide
+::::{grid-item-card} {octicon}`pencil;1.5em;sd-mr-1` Editors Guide
 :link: how-to/editors-guide
 :link-type: doc
 :class-header: bg-light
 
 ✨ Our editor guide will walk you through the editorial process. ✨
-:::
 ::::
 
-::::{grid-item}
-:::{card} {octicon}`codescan-checkmark;1.5em;sd-mr-1` For Reviewers
+::::{grid-item-card} {octicon}`codescan-checkmark;1.5em;sd-mr-1` For Reviewers
 :link: how-to/reviewer-guide
 :link-type: doc
 :class-header: bg-light
@@ -85,11 +76,9 @@ Are you a reviewer? ✨
 
 Click here to read our reviewer guide which will walk you through the review
 process step-by-step.
-:::
 ::::
 
-::::{grid-item}
-:::{card} {octicon}`people;1.5em;sd-mr-1` Our Partners
+::::{grid-item-card} {octicon}`people;1.5em;sd-mr-1` Our Partners
 :link: partners/scientific-communities
 :link-type: doc
 :class-header: bg-light
@@ -98,7 +87,6 @@ Scientific Community Partnerships ✨
 
 We partner with other scientific communities. Learn about our partnerships with
 JOSS and Pangeo.
-:::
 ::::
 
 :::::


### PR DESCRIPTION
Hi! This is a tiny PR for the homepage because I noticed the footers are misaligned, and that looks a little odd. [The `grid-item-card` directive in Sphinx-Design](https://arc.net/l/quote/bygkcglm) is designed to use exactly for this purpose. I've changed the cards to use it here.

| Before | After |
|--------|--------|
| <img width="1812" height="1222" alt="127 0 0 1_8000_ (1)" src="https://github.com/user-attachments/assets/0db58175-c66a-44cc-8dc3-d7ffefdcc8a1" /> | <img width="1812" height="1156" alt="127 0 0 1_8000_" src="https://github.com/user-attachments/assets/0ecd56b0-7e76-4968-a469-4ff4da668425" /> |

P.S. The "Authors Guide" text fits within one line, and the cards on its left don't, which makes it a bit misaligned. However, I'd still say this is an improvement over the previous layout and isn't as jarring to the eye 😉

Thank you :)