### PR TITLE
fix: update file paths to match Hugo-based pyopensci.github.io 

### DIFF
--- a/appendices/templates.md
+++ b/appendices/templates.md
@@ -30,8 +30,8 @@ Editors may make use of the e-mail template below in recruiting reviewers:
 
 There are a few things left to do to wrap up this submission:
 - [ ] Add the badge for pyOpenSci peer-review to the README.md of <package-name-here>. The badge should be `[![pyOpenSci](https://tinyurl.com/y22nb8up)](https://github.com/pyOpenSci/software-review/issues/issue-number)`
-- [ ] Add <package-name> to the pyOpenSci website. <maintainer-name>, please open a pr to update [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/packages.yml): to add your package and name to the list of contributors
-- [ ] <reviewers-and-maintainers> if you have time and are open to being listed on our website, please add yourselves to [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) via a pr so we can list you on our website as contributors!
+- [ ] Add <package-name> to the pyOpenSci website. <maintainer-name>, please open a pr to update [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/data/packages.yml): to add your package and name to the list of contributors
+- [ ] <reviewers-and-maintainers> if you have time and are open to being listed on our website, please add yourselves to [this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/data/contributors.yml) via a pr so we can list you on our website as contributors!
 
 <IF JOSS SUBMISSION>
 This package is going to move on to JOSS for review. I believe @arfon will ask you to implement the items below but let's let him chime in here first!

--- a/how-to/onboarding-guide.md
+++ b/how-to/onboarding-guide.md
@@ -247,7 +247,7 @@ To onboard a new editor:
 * Add the new editor to the pyOpenSci Slack workspace and specifically the `private-editorial` channel.
 
 * Post a welcome message for the new editor in the editor channel, pinging all editors.
-* Update the [website contributors.yml](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) file with the name of the new editor.
+* Update the [website contributors.yml](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/data/contributors.yml) file with the name of the new editor.
 
 :::{note}
 We have a bi-weekly cron job that parses through existing issues and grabs the names of editors, reviewers and authors. However, if you want the editors name to be listed on the website prior to a review beginning and/or sooner than the cron job might pick up their name, then we suggest that you add their name, and GitHub username and title to the contributors.yml file through a pull request.
@@ -279,7 +279,7 @@ When it is time for an editor to step down, do the following:
 * Thank them for their work!
 * Announce that they are stepping down, and than them in the private editors-only Slack channel. Then, remove them from the editors-only Slack channel.
 * Remove them from the [Editorial-Board GitHub team](https://github.com/orgs/pyOpenSci/teams/editorial-board).
-* Move them to `emeritus-editor` on the [pyOpenSci website](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/contributors.yml) by editing the yaml file as follows:
+* Move them to `emeritus-editor` on the [pyOpenSci website](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/data/contributors.yml) by editing the yaml file as follows:
 
 ```yaml
 - name: FirstName LastName

--- a/partners/scientific-communities.md
+++ b/partners/scientific-communities.md
@@ -200,7 +200,7 @@ editor, who is a member of your community, will evaluate the package at the begi
 :animate: fade-in-slide-down
 
 You can also access are most recent list of accepted packages using this [.yml file which drives
-our website here](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/_data/packages.yml).
+our website here](https://github.com/pyOpenSci/pyopensci.github.io/blob/main/data/packages.yml).
 This file is updated using a cron job several times a month and can be filtered by your specific community to support your website development workflow. [The full listing of packages can be found here.](https://www.pyopensci.org/python-packages.html)
 :::
 


### PR DESCRIPTION
closes #394 
Update file paths to match Hugo-based pyopensci.github.io and restore compatibility with the contributor update workflow