### PR TITLE
ci: update docs workflow to Python 3.11

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Upgrade pip
         run: |

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Upgrade pip
         run: |

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -11,11 +11,11 @@ jobs:
   build-test-book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Fetch all history to get all tags
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -61,7 +61,7 @@ jobs:
             --ignore-urls "https://github.com/pyOpenSci/software-review/issues/18#issuecomment-581752433,https://github.com/pyOpenSci/software-review/issues/18#issuecomment-579520816,https://github.com/hpi-dhc/devicely,https://github.com/pyOpenSci/pyos-package-template"
       # Save html as artifact
       - name: Save book html as artifact for viewing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: book-html
           path: |


### PR DESCRIPTION
Update docs workflow to Python 3.11 to ensure compatibility with the current `argcomplete` dependency

